### PR TITLE
platformio: Add fixed espressif framework version

### DIFF
--- a/docker/platformio/Dockerfile
+++ b/docker/platformio/Dockerfile
@@ -17,4 +17,4 @@ ENV PATH="${PATH}:/home/developer/.platformio/packages/toolchain-xtensa32/bin/"
 
 ARG platformio_version
 RUN pip3 install --no-cache --upgrade pip setuptools wheel platformio==${platformio_version}
-RUN pio platform install espressif32@1.11.1 --with-package framework-espidf
+RUN pio platform install espressif32 --with-package framework-espidf

--- a/docker/platformio/Dockerfile
+++ b/docker/platformio/Dockerfile
@@ -17,4 +17,4 @@ ENV PATH="${PATH}:/home/developer/.platformio/packages/toolchain-xtensa32/bin/"
 
 ARG platformio_version
 RUN pip3 install --no-cache --upgrade pip setuptools wheel platformio==${platformio_version}
-RUN pio platform install espressif32 --with-package framework-espidf
+RUN pio platform install espressif32@1.11.1 --with-package framework-espidf

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 [env]
-platform = espressif32
+platform = espressif32@1.11.1
 board = pico32
 framework = espidf
 


### PR DESCRIPTION
This will avoid breaking the project by accident and problems
caused by using a different framework version.
This should only be increased after intensive testing

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>