### PR TITLE
docker: platformio remove install of framework from dockerfile

### DIFF
--- a/docker/platformio/Dockerfile
+++ b/docker/platformio/Dockerfile
@@ -17,4 +17,3 @@ ENV PATH="${PATH}:/home/developer/.platformio/packages/toolchain-xtensa32/bin/"
 
 ARG platformio_version
 RUN pip3 install --no-cache --upgrade pip setuptools wheel platformio==${platformio_version}
-RUN pio platform install espressif32 --with-package framework-espidf


### PR DESCRIPTION
This will avoid the installation of an unneeded framework in cases
where the development version and the most recent version differ.

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>