### PR TITLE
makefile:check if dialog is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ check-monitor: | check-docker check-dev
 TARGET += dev
 HELP_dev = specifies which USB device to connect to
 dev:
+ifeq (,$(shell which dialog))
+	$(error dialog is not installed)
+endif
 	export DEV=$$((for dev in $$(ls /dev/serial/by-id); do echo "$$(readlink -f /dev/serial/by-id/$$dev) $$dev "; done ) \
 	| dialog \
 		--stdout \


### PR DESCRIPTION
If dialog is not installed no error will be shown because _clear_ is called later on. This will first check if dialog is installed and abort with an error message if it is not.