### PR TITLE
makefile:feature set git pull mode to rebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,5 +144,6 @@ SETUP += setup-git
 HELP_setup-git = setup git commit message
 setup-git:
 	git config --replace-all commit.template .gitcommitmsg
+	git config --replace-all pull.rebase true
 
 include .Makefile.template


### PR DESCRIPTION
To minimize generated merge commits by git, I set the default git pull mode to rebase.
Merges are still possible by an explicit `git merge`