### PR TITLE
pio: Add git commit id and build time as version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,9 @@
 platform = espressif32@1.11.1
 board = pico32
 framework = espidf
+build_flags =
+	-DBUILD_TIME=$UNIX_TIME
+	!python3 -c 'import subprocess; rev = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip(); print("-DGIT_COMMIT_ID_SHORT=\\\"{}\\\"".format(rev.decode("ASCII")))'
 
 [env:pico32]
 board = pico32


### PR DESCRIPTION
This enables a more verbose tracking which version currently runs
on a given ESP.
This maybe helpful during debugging

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>