### PR TITLE
esp32:fix Changed timout for channel_queue test

### DIFF
--- a/components/channel/test/channel_test.c
+++ b/components/channel/test/channel_test.c
@@ -501,7 +501,7 @@ TEST_CASE("channel_queue", "[channel]")
 
     Channel_broadcast br;
     int test_data = 3;
-    channel_broadcast_init(&br, &cp, &test_data, 1);
+    channel_broadcast_init(&br, &cp, &test_data, uxTaskGetNumberOfTasks());
     UBaseType_t res = channel_broadcast(&br);
     TEST_ASSERT_EQUAL_INT(pdPASS, res);
     vTaskDelay(5);


### PR DESCRIPTION
<!-- THANKS FOR YOUR CONTRIBUTION! -->
<!-- please fill out this form so we get an idea what you did -->

## Related Issues & PRs
<!-- List of related PRs and issues. -->
<!-- IF NO ISSUE EXISTS, CREATE ONE FIRST! -->
<!-- this helps managing discussions! -->
<!-- or -->
- #76 

## Description
<!-- List of clear and concise descriptions regarding your contribution. -->
<!-- Also add things you think are missing -->
<!-- IF ANYTHING IS UNCHECKED CONSIDER ADDING THIS PR AS DRAFT! -->
- [x] Fix too short timeout in `channel_queue` test by setting timeout to number of running tasks

## Context
<!-- Additonal information why you did this. -->
<!-- Feel free to add screenshots or code to help explain your contribution. -->
Assuming, the test fails because there are more then one task runnable with same or higher Priority.
Setting the timeout to the number of running tasks should ensure, that all tasks get scheduled before timeout get's hit.